### PR TITLE
Sug 92 see no suggestions page after rejecting all suggestions

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -92,15 +92,15 @@ function App() {
         <Route path="/timeGrab"element={<TimeGrab/>}/>
         <Route path="/dietaryRestrictions"element={<DietCheck user={user} globalState={state} setGlobalState={setState}/>}/>
         <Route path="/location" element={<DistanceGrab user={user} setGlobalState={setState} globalState={state}/>}/>
-        <Route path="/account/filters" element={<Preferences user={user} setGlobalState={setState} updated={state.updated} />}/>
+        <Route path="/account/filters" element={<Preferences user={user} globalState={state} setGlobalState={setState}/>}/>
         <Route path="/account/allergies" element={<Allergies user={user}/>}/>
-        <Route path='/selectCuisine' element={<Cuisine user={user} setGlobalState={setState}/>} />
-        <Route path='/expandRadius' element={<ExpandRadius globalState={state}/>} />
+        <Route path='/selectCuisine' element={<Cuisine globalState={state} user={user} setGlobalState={setState}/>} />
+        <Route path='/expandRadius' element={<ExpandRadius setGlobalState={setState} globalState={state}/>} />
         {/* <Route path='/generateCodePage' element={<GetCodePage />}/> */}
         <Route path='/group/join' element={<Group isHost={false} globalState={state} setGlobalState={setState} />} />
         <Route path='/group/host' element={<Group isHost={true} />} />
         <Route path='/group/waiting' element={<GroupWaiting globalState={state} setGlobalState={setState} />} />
-        <Route path='/recommendations/waiting' element={<WaitingForRecommendation setGlobalState={setState} />} />
+        <Route path='/recommendations/waiting' element={<WaitingForRecommendation globalState={state} message={state.waitingMessage} setGlobalState={setState} />} />
         <Route path='/waiting/' element={<UserWaiting setGlobalState={setState} globalState={state} />} />
         <Route path = '/changeLocation' element = {<ChangeLocation/>}/>
       </Routes>

--- a/src/App.js
+++ b/src/App.js
@@ -92,9 +92,9 @@ function App() {
         <Route path="/timeGrab"element={<TimeGrab user={user}/>}/>
         <Route path="/dietaryRestrictions"element={<DietCheck user={user} globalState={state} setGlobalState={setState}/>}/>
         <Route path="/location" element={<DistanceGrab user={user} setGlobalState={setState} globalState={state}/>}/>
-        <Route path="/account/filters" element={<Preferences user={user} globalState={state} setGlobalState={setState}/>}/>
+        <Route path="/account/filters" element={<Preferences user={user} setGlobalState={setState} updated={state.updated}/>}/>
         <Route path="/account/allergies" element={<Allergies user={user}/>}/>
-        <Route path='/selectCuisine' element={<Cuisine globalState={state} user={user} setGlobalState={setState}/>} />
+        <Route path='/selectCuisine' element={<Cuisine user={user} setGlobalState={setState}/>} />
         <Route path='/expandRadius' element={<ExpandRadius setGlobalState={setState} globalState={state}/>} />
         {/* <Route path='/generateCodePage' element={<GetCodePage />}/> */}
         <Route path='/group/join' element={<Group isHost={false} globalState={state} setGlobalState={setState} />} />

--- a/src/components/ExpandRadiusPage.js
+++ b/src/components/ExpandRadiusPage.js
@@ -91,7 +91,7 @@ const ExpandRadius = ({globalState, setGlobalState}) => {
             className="d-flex align-items-center justify-content-center"
             style={{ minHeight: "100vh" }}
         >
-            <BackButton to='/keywordGrab'/>
+            <BackButton to='/location'/>
             <HomeButton/>
             <div className="w-100" style={{ maxWidth: "400px" }}>
                 <>

--- a/src/components/ExpandRadiusPage.js
+++ b/src/components/ExpandRadiusPage.js
@@ -36,8 +36,12 @@ const ExpandRadius = ({globalState, setGlobalState}) => {
                 longitude: cookies["latlong"]["longitude"],
                 distance: distRef.current.value
             }
-            console.log("check2")
+
             setCookie('latlong', latlong, { path: '/' });
+            if (cookies['groupCode'] != 0 && cookies['host'] === 'true') {
+                updateGroupHost(cookies['groupCode'], 'latlong', latlong);
+            }
+
             // They've submitted the form, allow decNumUsersReady again.
             setGlobalState({
                 ...globalState,
@@ -82,7 +86,7 @@ const ExpandRadius = ({globalState, setGlobalState}) => {
             className="d-flex align-items-center justify-content-center"
             style={{ minHeight: "100vh" }}
         >
-            <BackButton to='/location'/>
+            <BackButton to='/keywordGrab'/>
             <HomeButton/>
             <div className="w-100" style={{ maxWidth: "400px" }}>
                 <>

--- a/src/components/GroupWaiting.js
+++ b/src/components/GroupWaiting.js
@@ -48,7 +48,7 @@ const GroupWaiting = ({globalState, setGlobalState}) => {
         e && e.preventDefault();
         navigate("/recommendations/waiting")
         const groupCode = cookies["groupCode"]
-        updateGroupHost(groupCode, "hostReady", true)
+        // updateGroupHost(groupCode, "hostReady", true)
         const jsonData = await getGroupInfo(groupCode)  //run recommendation algorithm and navigate to recommendations page
         try {
             console.log('inside try catch');

--- a/src/components/GroupWaiting.js
+++ b/src/components/GroupWaiting.js
@@ -48,8 +48,10 @@ const GroupWaiting = ({globalState, setGlobalState}) => {
         e && e.preventDefault();
         navigate("/recommendations/waiting")
         const groupCode = cookies["groupCode"]
-        // updateGroupHost(groupCode, "hostReady", true)
+        updateGroupHost(groupCode, "hostReady", true)
         const jsonData = await getGroupInfo(groupCode)  //run recommendation algorithm and navigate to recommendations page
+        jsonData['latlong'] = cookies['latlong'];
+        console.log(jsonData);
         try {
             console.log('inside try catch');
             fetch("http://localhost:5000/data", {

--- a/src/components/GroupWaiting.js
+++ b/src/components/GroupWaiting.js
@@ -22,8 +22,6 @@ const GroupWaiting = ({globalState, setGlobalState}) => {
             return (group.skip) || (group.numUsers == group.numUsersReady);
         }
         detectGroupDone().then((groupReady) => {
-            console.log('groupReady');
-            console.log(groupReady);
             if (groupReady) {
                 const isHost = cookies["host"]; // 'true', 'false'
                 if(!(isHost == 'true'))
@@ -40,7 +38,6 @@ const GroupWaiting = ({globalState, setGlobalState}) => {
     useEffect(() => {
         const interval = setInterval(() => {
             updateVars()
-            // console.log('Logs every second');
         }, MINUTE_MS);
 
         return () => clearInterval(interval); // This represents the unmount function, in which you need to clear your interval to prevent memory leaks.
@@ -54,11 +51,8 @@ const GroupWaiting = ({globalState, setGlobalState}) => {
         
         const jsonData = await getGroupInfo(groupCode)  //run recommendation algorithm and navigate to recommendations page
         jsonData['latlong'] = cookies['latlong'];
-        console.log('GroupWaiting jsonData');
-        console.log(jsonData);
         navigate("/recommendations/waiting");
         try {
-            console.log('inside try catch');
             fetch("http://localhost:5000/data", {
                 method: "POST",
                 cache: "no-cache",
@@ -75,7 +69,6 @@ const GroupWaiting = ({globalState, setGlobalState}) => {
             }).then(json => {
                 if (typeof json != "object")
                 {
-                    console.log(json)
                     setGlobalState({...globalState, "failedToFind": json})
                     navigate("/expandRadius");
                 }
@@ -97,7 +90,7 @@ const GroupWaiting = ({globalState, setGlobalState}) => {
             });
         } catch (e) {
             // else set an error
-            console.err(e)
+            console.error(e)
         }
     }
 

--- a/src/components/GroupWaiting.js
+++ b/src/components/GroupWaiting.js
@@ -81,13 +81,20 @@ const GroupWaiting = ({globalState, setGlobalState}) => {
                 }
                 else
                 {
-                    updateGroupHost(groupCode, "haveSuggestions", true);
-                    setCookie("businesslist", json, { path: '/' });
-                    setGlobalState({...globalState, 'businesslist': json});
-                    setGlobalState({...globalState, "failedToFind": false})
-                    navigate("/recommendations");
+                    updateGroupHost(groupCode, "haveSuggestions", true)
+                    .then((b) => getGroup(groupCode))
+                    .then((group) => {
+                        const suggestions = Object.keys(group.suggestions);
+                        setCookie("businesslist", suggestions, { path: '/' });
+                        setGlobalState(prevState => ({
+                            ...prevState, 
+                            'businesslist': suggestions,
+                            "failedToFind": false
+                        }));
+                        navigate("/recommendations");
+                    });
                 }
-            })
+            });
         } catch (e) {
             // else set an error
             console.err(e)

--- a/src/components/KeywordGrab.js
+++ b/src/components/KeywordGrab.js
@@ -21,7 +21,6 @@ const KeywordGrab = ({setGlobalState, user, globalState}) => {
             const group = await getGroup(groupCode)
             if (group && group["hostReady"] != undefined)
             {
-                console.log(group.hostReady)
                 return group.hostReady
             }
             else

--- a/src/components/KeywordGrab.js
+++ b/src/components/KeywordGrab.js
@@ -19,9 +19,9 @@ const KeywordGrab = ({setGlobalState, user, globalState}) => {
         if (groupCode != 0)
         {
             const group = await getGroup(groupCode)
-            if (group && group["hostReady"] != undefined)
+            if (group && group["skip"] != undefined)
             {
-                return group.hostReady
+                return group.skip
             }
             else
             {
@@ -48,7 +48,7 @@ const KeywordGrab = ({setGlobalState, user, globalState}) => {
         return () => clearInterval(interval); // This represents the unmount function, in which you need to clear your interval to prevent memory leaks.
     }, [])
 
-    async function lmao()
+    async function stub()
     {
         console.log("Can't believe this works.")
         return 0
@@ -61,7 +61,7 @@ const KeywordGrab = ({setGlobalState, user, globalState}) => {
 
             setCookie('keywords', keywordRef.current.value, { path: '/' });
 
-            const check = user.isAnonymous ? lmao().then(e => {
+            const check = user.isAnonymous ? stub().then(e => {
                 console.log("Check123")
                 const jsonData = {
                     keywords: keywordRef.current.value,

--- a/src/components/Preferences.jsx
+++ b/src/components/Preferences.jsx
@@ -6,7 +6,7 @@ import { Container, Card } from "react-bootstrap";
 import Popup from './Popup';
 import { BackButton } from "./Buttons";
 
-function Preferences({ user, setGlobalState, globalState }) {
+function Preferences({ user, setGlobalState }) {
     const updated = globalState.updated;
     const [FamilyFriendly, setFF] = useState(false);
     const [includeHis, setHis] = useState(false);
@@ -53,7 +53,7 @@ function Preferences({ user, setGlobalState, globalState }) {
     };
 
     const closePopup = () => {
-        setGlobalState({...globalState, "updated": false })
+        setGlobalState(prevState => ({...prevState, "updated": false }))
         console.log("CLOSE POPUP")
     };
 

--- a/src/components/Preferences.jsx
+++ b/src/components/Preferences.jsx
@@ -6,8 +6,7 @@ import { Container, Card } from "react-bootstrap";
 import Popup from './Popup';
 import { BackButton } from "./Buttons";
 
-function Preferences({ user, setGlobalState }) {
-    const updated = globalState.updated;
+function Preferences({ user, setGlobalState, updated }) {
     const [FamilyFriendly, setFF] = useState(false);
     const [includeHis, setHis] = useState(false);
     const [minRating, setMR] = useState(0);

--- a/src/components/Preferences.jsx
+++ b/src/components/Preferences.jsx
@@ -6,8 +6,8 @@ import { Container, Card } from "react-bootstrap";
 import Popup from './Popup';
 import { BackButton } from "./Buttons";
 
-function Preferences({ user, setGlobalState, updated }) {
-
+function Preferences({ user, setGlobalState, globalState }) {
+    const updated = globalState.updated;
     const [FamilyFriendly, setFF] = useState(false);
     const [includeHis, setHis] = useState(false);
     const [minRating, setMR] = useState(0);
@@ -53,7 +53,7 @@ function Preferences({ user, setGlobalState, updated }) {
     };
 
     const closePopup = () => {
-        setGlobalState({ "updated": false })
+        setGlobalState({...globalState, "updated": false })
         console.log("CLOSE POPUP")
     };
 

--- a/src/components/PresetCuisines.jsx
+++ b/src/components/PresetCuisines.jsx
@@ -4,7 +4,7 @@ import { getCuisines, updateUserCuisine, getFilters } from '../firestore';
 import "../styles/presetCuis.css";
 import { BackButton } from './Buttons';
 
-function PreSetCuisines({ user, setGlobalState, globalState }) {
+function PreSetCuisines({ user, setGlobalState }) {
 
     const [listOfCuisines, setCuisineList] = useState([]);
     const [userCuisineList, setUserCuisine] = useState([]);
@@ -37,7 +37,7 @@ function PreSetCuisines({ user, setGlobalState, globalState }) {
 
     const handleCheck = (event) => {
         var updatedList = [...checked];
-        setGlobalState({...globalState, 'updated': true })
+        setGlobalState(prevState => ({...prevState, 'updated': true }))
         if (event.target.checked) {
             updatedList = [...checked, event.target.value];
         } else {

--- a/src/components/PresetCuisines.jsx
+++ b/src/components/PresetCuisines.jsx
@@ -4,7 +4,7 @@ import { getCuisines, updateUserCuisine, getFilters } from '../firestore';
 import "../styles/presetCuis.css";
 import { BackButton } from './Buttons';
 
-function PreSetCuisines({ user, setGlobalState }) {
+function PreSetCuisines({ user, setGlobalState, globalState }) {
 
     const [listOfCuisines, setCuisineList] = useState([]);
     const [userCuisineList, setUserCuisine] = useState([]);
@@ -37,7 +37,7 @@ function PreSetCuisines({ user, setGlobalState }) {
 
     const handleCheck = (event) => {
         var updatedList = [...checked];
-        setGlobalState({ 'updated': true })
+        setGlobalState({...globalState, 'updated': true })
         if (event.target.checked) {
             updatedList = [...checked, event.target.value];
         } else {

--- a/src/components/Recommendations.js
+++ b/src/components/Recommendations.js
@@ -23,7 +23,6 @@ class Recommendations extends React.Component {
         i % 2 == 0 ? newRestIds.push(restIds[Math.trunc(i / 2)]) : newRestIds.push(`groupDecision-${restIds.length * 2 - i}`);
       }
       restIds = newRestIds.reverse();
-      // console.log(restIds);
     } else {
       const newRestIds = [];
       for (let i = 0; i < restIds.length; ++i) {
@@ -105,17 +104,11 @@ class Recommendations extends React.Component {
           this.navToMap({ setGlobalState: this.state.setGlobalState, business_id: this.state.restIds[index + 1] });
         }
       }
-      console.log('this.state.index');
-      console.log(this.state.index);
-      console.log('this.state.childRefs.length');
-      console.log(this.state.childRefs().length);
       if (this.state.index < 0) { // if there are no more recommendations
         if (this.state.host === 'true') { // Navigate to increase radius if host.
           // *** host decrements numUsersReady in /expandRadius. ***
           this.state.showNoRecs = true;
         } else { // group members wait for host.
-          console.log('Recommendations Member groupCode')
-          console.log(state.groupCode);
           updateGroupMember(state.groupCode, 'numUsersReady', null);
           this.state.showNoRecsGroupMember = true
         }
@@ -380,9 +373,6 @@ const GroupDecision = (props) => {
   const [restaurant, setRestaurant] = useState([]);
   const [group, setGroup] = useState({});
   // Update restaurant;
-  // console.log('passRef');
-  // console.log(passRef);
-  // console.log(props);
   useEffect(() => {
     async function setRes() {
       const rest = await getRestaurantById(restId);

--- a/src/components/Recommendations.js
+++ b/src/components/Recommendations.js
@@ -107,17 +107,17 @@ class Recommendations extends React.Component {
           this.navToMap({ setGlobalState: this.state.setGlobalState, business_id: this.state.restIds[index + 1] });
         }
       }
-
-      if (this.state.index === this.state.childRefs.length) { // if there are no more recommendations
+      console.log('this.state.index');
+      console.log(this.state.index);
+      console.log('this.state.childRefs.length');
+      console.log(this.state.childRefs().length);
+      if (this.state.index < 0) { // if there are no more recommendations
         if (this.state.host === 'true') { // Navigate to increase radius if host.
-          updateGroupHost(state.groupCode, 'hostReady', false);
+          // *** host decrements numUsersReady in /expandRadius. ***
           this.state.showNoRecs = true;
         } else { // group members wait for host.
           console.log('Recommendations Member groupCode')
           console.log(state.groupCode);
-          // host also decrements but in /expandRadius. If no suggestions fit the query, it will still
-          // decrement, but we don't want to double decrement it if there are suggestions but all are 
-          // rejected 
           updateGroupMember(state.groupCode, 'numUsersReady', null);
           this.state.showNoRecsGroupMember = true
         }
@@ -236,7 +236,7 @@ class Recommendations extends React.Component {
     return (
       <div className="recommendations">
         {/* No recommendations, member */}
-        {this.state.showNoRecsGroupMember && (<Navigate to={'/recommendations/waiting'} />)}
+        {this.state.showNoRecsGroupMember && (<Navigate to={'/keywordGrab'} />)}
         {/* No recommendations solo or host */}
         {this.state.showNoRecs && (<Navigate to={'/expandRadius'} />)}
         {/* Accepted recommendation */}

--- a/src/components/Recommendations.js
+++ b/src/components/Recommendations.js
@@ -14,9 +14,7 @@ import { BackButton, HomeButton } from "./Buttons";
 class Recommendations extends React.Component {
   constructor(props) {
     super(props);
-    // idk why this cookie keeps being assigned the name 'businesslist', it's
-    // driving me crazy.
-    var restIds = props.recommendationIds || props.allCookies['businesslist'] || props.allCookies['businesslist']; // .reverse()
+    var restIds = props.recommendationIds;
     restIds = restIds.sort();
     if (props.allCookies['groupCode'] != 0) {
       // in a group, insert groupDecision cards between each restaurant.

--- a/src/components/UserWaiting.js
+++ b/src/components/UserWaiting.js
@@ -19,7 +19,7 @@ const UserWaiting = ({ globalState, setGlobalState }) => {
     //     async function idk() {
     //         // setNumUsers(group.numUsers)
     //         // setNumUsersReady(group.numUsersReady)
-    //         // return (group.hostReady) || (group.numUsers == group.numUsersRead);
+    //         // return (group.skip) || (group.numUsers == group.numUsersRead);
     //         return
     //     }
     //     // console.log('inside use effect')

--- a/src/components/WaitingForRecommendation.js
+++ b/src/components/WaitingForRecommendation.js
@@ -13,27 +13,6 @@ const WaitingForRecommendation = (props) => {
     const [cookies, setCookie] = useCookies(['user']);
     const navigate = useNavigate();
 
-    // async function updateVars() {
-    //     const groupCode = cookies["groupCode"]
-    //     const group = await getGroup(groupCode)
-    //     // setNumUsers(group.numUsers)
-    //     // setNumUsersReady(group.numUsersReady)
-    //     if (group.suggestions != null) {
-    //         setCookie('businesslist', group.suggestions, { path: '/' });
-    //         navigate("/recommendations");
-    //     }
-    // }
-    // const MINUTE_MS = 1000;
-
-    // useEffect(() => {
-    //     const interval = setInterval(() => {
-    //         updateVars()
-    //         console.log('Logs every second');
-    //     }, MINUTE_MS);
-
-    //     return () => clearInterval(interval); // This represents the unmount function, in which you need to clear your interval to prevent memory leaks.
-    // }, [])
-
     const MINUTE_MS = 1000;
 
     async function idk() {
@@ -47,13 +26,14 @@ const WaitingForRecommendation = (props) => {
     async function checkGroupDone() {
         await idk().then((group) => {
             // if Not skipped and group not all ready, go back.
-            if (group && (!group['hostReady'] && group['numUsers'] !== group['numUsersReady'])) {
+            const skipped = cookies['host'] === 'true' ? globalState.skip : group['skip']
+            if (group && (!skipped && group['numUsers'] !== group['numUsersReady'])) {
                 console.log(group);
-                updateGroupMember(group['groupCode'], 'numUsersReady', null);
-                navigate('/keywordGrab');
-            } else if (group && group["suggestions"] !== undefined) {
-                // console.log(typeof group.suggestions);
-                // console.log(Object.keys(group.suggestions));
+                updateGroupMember(group['groupCode'], 'numUsersReady', null).then((b) => {
+                    navigate('/keywordGrab');
+                });
+            } else if (group && group["haveSuggestions"]) {
+                // Host might be getting a new set of recommendations. Wait for those instead!
                 let suggestions = Object.keys(group.suggestions);
                 suggestions.sort();
                 console.log(suggestions);

--- a/src/components/WaitingForRecommendation.js
+++ b/src/components/WaitingForRecommendation.js
@@ -46,7 +46,7 @@ const WaitingForRecommendation = (props) => {
 
     async function checkGroupDone() {
         await idk().then((group) => {
-            // If the host ain't ready, go back! 
+            // if Not skipped and group not all ready, go back.
             if (group && (!group['hostReady'] && group['numUsers'] !== group['numUsersReady'])) {
                 console.log(group);
                 updateGroupMember(group['groupCode'], 'numUsersReady', null);

--- a/src/components/dietCheck.js
+++ b/src/components/dietCheck.js
@@ -32,11 +32,9 @@ const DietCheck = ({ user, globalState, setGlobalState }) => {
         const groupCode = cookies["groupCode"]
         if (groupCode != 0) {
             const group = await getGroup(groupCode)
-            if (group && group["hostReady"] != undefined) {
-                console.log(group.hostReady)
-                return group.hostReady
-            }
-            else {
+            if (group && group["skip"] != undefined) {
+                return group.skip
+            } else {
                 return false
             }
         }

--- a/src/components/priceCheck.js
+++ b/src/components/priceCheck.js
@@ -24,9 +24,9 @@ const PriceGrab = ({ globalState, setGlobalState }) => {
         const groupCode = cookies["groupCode"]
         if (groupCode != 0) {
             const group = await getGroup(groupCode)
-            if (group && group["hostReady"] != undefined) {
-                console.log(group.hostReady)
-                return group.hostReady
+            if (group && group["skip"] != undefined) {
+                console.log(group.skip)
+                return group.skip
             }
             else {
                 return false

--- a/src/firestore.js
+++ b/src/firestore.js
@@ -780,10 +780,6 @@ async function joinGroup(code, user) {
  * @returns 
  */
 async function updateGroupMember(code, key, value) {
-  console.log('updateGroupMember')
-  console.log(code);
-  console.log(key);
-  console.log(value);
   if (!(await groupExists(code))) {
     return false;
   }
@@ -856,9 +852,9 @@ function updateGroupMemberTransaction(key, value, user, groupDocRef) {
         break;
       default:
         try {
-          console.err(`invalid atomic transaction key ${key}, must be one of: ['keywords', 'numUsersReady']`);
+          console.error(`invalid atomic transaction key ${key}, must be one of: ['keywords', 'numUsersReady']`);
         } catch(e) {
-          console.err('Invalid atomic transaction key:');
+          console.error('Invalid atomic transaction key:');
           console.print(key);
         }
         break;
@@ -868,10 +864,6 @@ function updateGroupMemberTransaction(key, value, user, groupDocRef) {
 }
 
 async function updateGroupHost(code, key, value) {
-  console.log('updateGroupHost');
-  console.log(code);
-  console.log(key);
-  console.log(value);
   if (!(await isHost(code, getAuth().currentUser))) {
     console.error("Not the group's host!");
     return false;
@@ -882,7 +874,7 @@ async function updateGroupHost(code, key, value) {
   }
 
   if (!supportedHostGroupKeys.includes(key)) {
-    console.err(`Cannot update key ${key} in group ${code}!`);
+    console.error(`Cannot update key ${key} in group ${code}!`);
     return false;
   }
 

--- a/src/firestore.js
+++ b/src/firestore.js
@@ -2,7 +2,7 @@ import { initializeApp } from "firebase/app";
 import { getAnalytics } from "firebase/analytics";
 import { getAuth, createUserWithEmailAndPassword, signInWithEmailAndPassword, GoogleAuthProvider, signInWithPopup, signInWithRedirect, getRedirectResult, signOut, signInAnonymously, sendPasswordResetEmail, updatePassword } from "firebase/auth"
 import { getStorage, ref, listAll, getDownloadURL } from "firebase/storage"
-import { getFirestore, collection, getDocs, getDoc, Timestamp, doc, setDoc, deleteDoc, updateDoc, query, where, limit, onSnapshot, getCountFromServer } from "firebase/firestore";
+import { getFirestore, collection, getDocs, getDoc, Timestamp, doc, setDoc, deleteDoc, updateDoc, query, where, limit, onSnapshot, getCountFromServer, runTransaction } from "firebase/firestore";
 
 // Your web app's Firebase configuration
 // For Firebase JS SDK v7.20.0 and later, measurementId is optional
@@ -19,9 +19,10 @@ const firebaseConfig = {
 const firebaseApp = initializeApp(firebaseConfig);
 const db = getFirestore(firebaseApp);
 const auth = getAuth(firebaseApp);
-const supportedMemberGroupKeys = ['diet', 'keywords', 'price', 'users', 'suggestions'];
-const supportedHostGroupKeys = supportedMemberGroupKeys.concat('latlong', 'time');
-
+const supportedMemberGroupKeys = ['numUsersReady', 'diet', 'keywords', 'price', 'users', 'suggestions'];
+const supportedHostGroupKeys = supportedMemberGroupKeys.concat('latlong', 'time', 'hostReady', 'decision');
+// document keys that require atomic read/write operations go in transactionKeys
+const transactionKeys = ['numUsersReady', 'keywords'];
 // localize OAuth flow to user's preferred language.
 auth.languageCode = 'it';
 auth.useDeviceLanguage();
@@ -482,6 +483,9 @@ async function getGroup(groupId) {
 
 async function groupExists(groupId) {
   const docRef = await getDoc(doc(db, 'groups', String(groupId)));
+  if(!docRef.exists()) {
+    console.log(`Group ${groupId} doesn't exist`);
+  }
   return docRef.exists();
 }
 
@@ -761,7 +765,6 @@ function defaultGroupUserData(currentUser) {
 
 async function joinGroup(code, user) {
   if (!(await groupExists(code))) {
-    console.log("Group doesn't exist.");
     return null;
   }
 
@@ -777,28 +780,35 @@ async function joinGroup(code, user) {
  * @returns 
  */
 async function updateGroupMember(code, key, value) {
+  console.log('updateGroupMember')
+  console.log(code);
+  console.log(key);
+  console.log(value);
   if (!(await groupExists(code))) {
-    console.log("Group doesn't exist.");
     return false;
   }
   const user = getAuth().currentUser;
   const groupDocRef = doc(db, 'groups', code);
+  // numUsersReady requires an atomic read/write because multiple users,
+  // might be trying to update that number at once (i.e. if multiple 
+  // users finish the quiz at the same time), so we have to use a
+  // transaction to avoid a race condition.
+  if (transactionKeys.includes(key)) {
+    runTransaction(db, updateGroupMemberTransaction(key, value, user, groupDocRef));
+    return true;
+  }
   const groupDoc = (await getDoc(groupDocRef)).data();
   const userData = groupDoc['data'][user.uid];
+
   switch (key) {
     case 'users':
       if (groupDoc.users.includes(value)) {
         console.log("Already in group");
         return true;
       }
-      // console.log(groupDoc[key]);
       groupDoc[key] = groupDoc[key].concat(value);
       groupDoc['numUsers'] = groupDoc[key].length;
       groupDoc['data'][user.uid] = defaultGroupUserData(user);
-      break;
-    case 'keywords':
-      userData[key] = value;
-      groupDoc['numUsersReady'] += 1;
       break;
     case 'price':
     case 'diet':
@@ -810,20 +820,58 @@ async function updateGroupMember(code, key, value) {
       groupDoc[key][acceptedRestaurantId][vk] += 1;
       break;
     default:
-      console.log(`Invalid update key: ${key}`);
-      return false
+      console.log(`Invalid group update key: ${key}`);
+      return false;
   }
   try {
     updateDoc(groupDocRef, groupDoc);
     return true;
   } catch (e) {
-    console.log("Failed to join group, see below reason:");
+    console.log("Failed to update group, see below reason:");
     console.error(e);
     return false;
   }
 }
 
+function updateGroupMemberTransaction(key, value, user, groupDocRef) {
+  return async (transaction) => {
+    const groupDoc = (await transaction.get(groupDocRef)).data();
+    const userData = groupDoc['data'][user.uid];
+    // If updating numUsersReady, decrement numUsersReady unless we update keywords.
+    let decNumUsersReady = true;
+    switch (key) {
+      case 'keywords':
+        userData[key] = value;
+        // Increment numUsersReady
+        decNumUsersReady = false;
+        // intentional fall-through
+      case 'numUsersReady':
+        // Unless also ran keywords, decrement numUsersReady
+        // Don't let numUsersReady get larger than numUsers or smaller than 0.
+        if (decNumUsersReady) {
+          groupDoc['numUsersReady'] = Math.max(groupDoc['numUsersReady']-1,0);
+        } else {
+          groupDoc['numUsersReady'] = Math.min(groupDoc['numUsersReady']+1, groupDoc['numUsers']);
+        }
+        break;
+      default:
+        try {
+          console.err(`invalid atomic transaction key ${key}, must be one of: ['keywords', 'numUsersReady']`);
+        } catch(e) {
+          console.err('Invalid atomic transaction key:');
+          console.print(key);
+        }
+        break;
+    }
+    transaction.update(groupDocRef, groupDoc);
+  }
+}
+
 async function updateGroupHost(code, key, value) {
+  console.log('updateGroupHost');
+  console.log(code);
+  console.log(key);
+  console.log(value);
   if (!(await isHost(code, getAuth().currentUser))) {
     console.error("Not the group's host!");
     return false;
@@ -831,6 +879,10 @@ async function updateGroupHost(code, key, value) {
 
   if (supportedMemberGroupKeys.includes(key)) {
     return updateGroupMember(code, key, value);
+  }
+
+  if (!supportedHostGroupKeys.includes(key)) {
+    console.err(`Cannot update key ${key} in group ${code}!`);
   }
 
   const groupDocRef = doc(db, 'groups', code);

--- a/src/python/server.py
+++ b/src/python/server.py
@@ -132,9 +132,7 @@ def userHandler(req, id_list):
 # have a way to find the new list for group members. 
 def insert_restaurants_as_suggestions(ids_list, group_id):
 	groupDocRef = db.document('groups', group_id)
-	# groupDoc = groupDocRef.get().to_dict()
 	suggestion_data = dict()
-	# suggestion_data = groupDoc['suggestions'] if 'suggestions' in groupDoc.keys() else dict()
 	for rest_id in ids_list:
 		suggestion_data[rest_id] = dict(numAccepted=0, numRejected=0)
 	groupDocRef.update({'suggestions': suggestion_data})

--- a/src/python/server.py
+++ b/src/python/server.py
@@ -128,10 +128,13 @@ def userHandler(req, id_list):
 
 
 # this uploads restaurants to group DB object for group mode
+# Overwrites suggestion data since for subsequent runs, client doesn't
+# have a way to find the new list for group members. 
 def insert_restaurants_as_suggestions(ids_list, group_id):
 	groupDocRef = db.document('groups', group_id)
-	groupDoc = groupDocRef.get().to_dict()
-	suggestion_data = groupDoc['suggestions'] if 'suggestions' in groupDoc.keys() else dict()
+	# groupDoc = groupDocRef.get().to_dict()
+	suggestion_data = dict()
+	# suggestion_data = groupDoc['suggestions'] if 'suggestions' in groupDoc.keys() else dict()
 	for rest_id in ids_list:
 		suggestion_data[rest_id] = dict(numAccepted=0, numRejected=0)
 	groupDocRef.update({'suggestions': suggestion_data})


### PR DESCRIPTION
Lots of touched files, sorry lads. 
- `hostReady` was renamed to `skip` and has been refactored to fit the name (i.e. it is no longer set in `runAlgorithm` in GroupWaiting.js). 
- ExpandRadius now functions for groups and single users, whether the algorithm returned no suggestions or the group/user rejects all suggestions. (Group members go directly back to the keywords page; Group Hosts and Single users go to ExpandRadius first, then Keywords, like how single users have been already).
- The Host now gets suggestions from the database rather than from the Python server directly. This helped fix a bug where local suggestions did not match the group's suggestion, but the code can most likely be refactored to use the returned value from the server as an optimization, I could not figure it out myself now. 
