### PR TITLE
ChangeLocation works without location services

### DIFF
--- a/src/components/distanceGrab.js
+++ b/src/components/distanceGrab.js
@@ -25,21 +25,6 @@ const DistanceGrab = ({ setGlobalState, globalState }) => {
             userDecisionTimeout: 5000,
         });
 
-    async function changeLocation()
-    {
-        const latlong = {
-            latitude: latRef.current.value,
-            longitude: longRef.current.value,
-            distance: distRef.current.value
-        }
-
-        setCookie('latlong', latlong, { path: '/' });
-        if (cookies['groupCode'] != 0 && cookies['host'] === 'true') {
-            updateGroupHost(cookies['groupCode'], 'latlong', latlong);
-        }
-        navigate("/changeLocation");
-    }
-
     async function handleSubmit(e) {
         e.preventDefault(); // don't refresh the page
         try {
@@ -153,7 +138,7 @@ const DistanceGrab = ({ setGlobalState, globalState }) => {
                     {/* </Card.Body>
                     </Card> */}
                 </>
-                <Button className="w-75 button-control" onClick={() => changeLocation()}>
+                <Button className="w-75 button-control" onClick={() => navigate('/changeLocation')}>
                     Change Location
                 </Button>
             </div>


### PR DESCRIPTION
Added distance input on change location page as well so we can still let them specify this. Also, users no longer have to click one of the drop down options in order for their input to count. So long as their input is a valid place (i.e. Berlin, Pittsburgh PA, Beijing, etc.) the library can grab the latlong from it. 